### PR TITLE
A Value object can now be cast to an int or a float

### DIFF
--- a/pyepsolartracer/registers.py
+++ b/pyepsolartracer/registers.py
@@ -49,6 +49,12 @@ class Value:
             return self.register.name + " = " + str(self.value) 
         return self.register.name + " = " + str(self.value) + self.register.unit()[1]
 
+    def __float__(self):
+        return float(self.value)
+
+    def __int__(self):
+        return int(self.value)
+
 class Register:
     def __init__(self, name, address, description, unit, times, size = 1):
         self.name = name


### PR DESCRIPTION
Added the ability to cast a Value object to an int or a float so no parsing is necessary if you just want the raw values, while preserving the current functionality.  There probably is a better way to do this with factories/metaclasses but I don't want to rework this too much.

Also,  tested and working on the Landstar series EPSolar controller.
