### PR TITLE
xr_usb: fix some whitespace errors

### DIFF
--- a/xr_usb_serial_common-1a/xr_usb_serial_common.c
+++ b/xr_usb_serial_common-1a/xr_usb_serial_common.c
@@ -270,9 +270,9 @@ static void xr_usb_serial_ctrl_irq(struct urb *urb)
 	case 0:
 		p = (unsigned char *)(urb->transfer_buffer);
 		for(i=0;i<urb->actual_length;i++)
-	    {
-          dev_dbg(&xr_usb_serial->control->dev,"0x%02x\n",p[i]);
-	    }
+		{
+			dev_dbg(&xr_usb_serial->control->dev,"0x%02x\n",p[i]);
+		}
 		/* success */
 		break;
 	case -ECONNRESET:
@@ -300,16 +300,16 @@ static void xr_usb_serial_ctrl_irq(struct urb *urb)
 		break;
 
 	case USB_CDC_NOTIFY_SERIAL_STATE:
-#if LINUX_VERSION_CODE > KERNEL_VERSION(3, 9, 0)		
+#if LINUX_VERSION_CODE > KERNEL_VERSION(3, 9, 0)
 		newctrl = get_unaligned_le16(data);
-    	if (!xr_usb_serial->clocal && (xr_usb_serial->ctrlin & ~newctrl & XR_USB_SERIAL_CTRL_DCD)) {
+	if (!xr_usb_serial->clocal && (xr_usb_serial->ctrlin & ~newctrl & XR_USB_SERIAL_CTRL_DCD)) {
 			dev_dbg(&xr_usb_serial->control->dev, "%s - calling hangup\n",
 					__func__);
 			tty_port_tty_hangup(&xr_usb_serial->port, false);
 		}
-#else		
+#else
 		tty = tty_port_tty_get(&xr_usb_serial->port);
-        newctrl = get_unaligned_le16(data);
+		newctrl = get_unaligned_le16(data);
 		if (tty)
 		{
 			if (!xr_usb_serial->clocal &&
@@ -390,7 +390,7 @@ static int xr_usb_serial_submit_read_urbs(struct xr_usb_serial *xr_usb_serial, g
 }
 static void xr_usb_serial_process_read_urb(struct xr_usb_serial *xr_usb_serial, struct urb *urb)
 {
-    struct tty_struct *tty;
+	struct tty_struct *tty;
 	if (!urb->actual_length)
 		return;
 #if LINUX_VERSION_CODE > KERNEL_VERSION(3, 9, 0)    
@@ -398,7 +398,7 @@ static void xr_usb_serial_process_read_urb(struct xr_usb_serial *xr_usb_serial, 
 			urb->actual_length);
 	tty_flip_buffer_push(&xr_usb_serial->port);
 #else
-    tty = tty_port_tty_get(&xr_usb_serial->port);
+	tty = tty_port_tty_get(&xr_usb_serial->port);
 	if (!tty)
 		return;
 	tty_insert_flip_string(tty, urb->transfer_buffer, urb->actual_length);
@@ -465,7 +465,7 @@ static void xr_usb_serial_write_bulk(struct urb *urb)
 static void xr_usb_serial_softint(struct work_struct *work)
 {
 	struct xr_usb_serial *xr_usb_serial = container_of(work, struct xr_usb_serial, work);
-    struct tty_struct *tty;
+	struct tty_struct *tty;
 	
 	dev_vdbg(&xr_usb_serial->data->dev, "%s\n", __func__);
 #if LINUX_VERSION_CODE > KERNEL_VERSION(3, 9, 0)
@@ -476,7 +476,7 @@ static void xr_usb_serial_softint(struct work_struct *work)
 		return;
 	tty_wakeup(tty);
 	tty_kref_put(tty);
-#endif	
+#endif
 }
 
 /*
@@ -585,9 +585,9 @@ static void xr_usb_serial_port_destruct(struct tty_port *port)
 	struct xr_usb_serial *xr_usb_serial = container_of(port, struct xr_usb_serial, port);
 
 	dev_dbg(&xr_usb_serial->control->dev, "%s\n", __func__);
-    #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 7, 0)
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 7, 0)
 	tty_unregister_device(xr_usb_serial_tty_driver, xr_usb_serial->minor);
-	#endif
+#endif
 	xr_usb_serial_release_minor(xr_usb_serial);
 	usb_put_intf(xr_usb_serial->control);
 	kfree(xr_usb_serial->country_codes);
@@ -825,9 +825,9 @@ static int xr_usb_serial_tty_ioctl(struct tty_struct *tty,
 {
 	struct xr_usb_serial *xr_usb_serial = tty->driver_data;
 	int rv = -ENOIOCTLCMD;
-    unsigned int  channel, reg, val;
+	unsigned int  channel, reg, val;
 
-    short	*data;
+	short	*data;
 	switch (cmd) {
 	case TIOCGSERIAL: /* gets serial port data */
 		rv = get_serial_info(xr_usb_serial, (struct serial_struct __user *) arg);
@@ -835,72 +835,73 @@ static int xr_usb_serial_tty_ioctl(struct tty_struct *tty,
 	case TIOCSSERIAL:
 		rv = set_serial_info(xr_usb_serial, (struct serial_struct __user *) arg);
 		break;
-    case XR_USB_SERIAL_GET_REG:
-                if (get_user(channel, (int __user *)arg))
-                        return -EFAULT;
-                if (get_user(reg, (int __user *)(arg + sizeof(int))))
-                        return -EFAULT;
+	case XR_USB_SERIAL_GET_REG:
+		if (get_user(channel, (int __user *)arg))
+			return -EFAULT;
+		if (get_user(reg, (int __user *)(arg + sizeof(int))))
+			return -EFAULT;
 
-                data = kmalloc(2, GFP_KERNEL);
-                if (data == NULL) {
-                        dev_err(&xr_usb_serial->control->dev, "%s - Cannot allocate USB buffer.\n", __func__);
-                        return -ENOMEM;
+		data = kmalloc(2, GFP_KERNEL);
+		if (data == NULL)
+		{
+			dev_err(&xr_usb_serial->control->dev, "%s - Cannot allocate USB buffer.\n", __func__);
+			return -ENOMEM;
 		}
-        			
-		        if (channel == -1)
-		        {
-		          rv = xr_usb_serial_get_reg(xr_usb_serial,reg, data);
-		        }
-				else
-				{
-			  	  rv = xr_usb_serial_get_reg_ext(xr_usb_serial,channel,reg, data);
-				}
-                if (rv != 1) {
-                        dev_err(&xr_usb_serial->control->dev, "Cannot get register (%d)\n", rv);
-                        kfree(data);
-                        return -EFAULT;
-                }
-				if (put_user(le16_to_cpu(*data), (int __user *)(arg + 2 * sizeof(int))))
-              	{
-                   dev_err(&xr_usb_serial->control->dev, "Cannot put user result\n");
-                   kfree(data);
-                   return -EFAULT;
-                }
-                rv = 0;
-                kfree(data);
-                break;
 
-      case XR_USB_SERIAL_SET_REG:
-                if (get_user(channel, (int __user *)arg))
-                        return -EFAULT;
-                if (get_user(reg, (int __user *)(arg + sizeof(int))))
-                        return -EFAULT;
-                if (get_user(val, (int __user *)(arg + 2 * sizeof(int))))
-                        return -EFAULT;
+		if (channel == -1)
+		{
+			rv = xr_usb_serial_get_reg(xr_usb_serial,reg, data);
+		}
+		else
+		{
+			rv = xr_usb_serial_get_reg_ext(xr_usb_serial,channel,reg, data);
+		}
+		if (rv != 1) {
+			dev_err(&xr_usb_serial->control->dev, "Cannot get register (%d)\n", rv);
+			kfree(data);
+			return -EFAULT;
+		}
+		if (put_user(le16_to_cpu(*data), (int __user *)(arg + 2 * sizeof(int))))
+		{
+			dev_err(&xr_usb_serial->control->dev, "Cannot put user result\n");
+			kfree(data);
+			return -EFAULT;
+		}
+		rv = 0;
+		kfree(data);
+		break;
 
-			if (channel == -1)
-			{
-				rv = xr_usb_serial_set_reg(xr_usb_serial,reg, val);
-			}
-			else
-			{
-			 	rv = xr_usb_serial_set_reg_ext(xr_usb_serial,channel,reg, val);
-				
-			}
-		    if (rv < 0)
-               return -EFAULT;  
-			rv = 0;
-            break;
+	case XR_USB_SERIAL_SET_REG:
+		if (get_user(channel, (int __user *)arg))
+			return -EFAULT;
+		if (get_user(reg, (int __user *)(arg + sizeof(int))))
+			return -EFAULT;
+		if (get_user(val, (int __user *)(arg + 2 * sizeof(int))))
+			return -EFAULT;
+
+		if (channel == -1)
+		{
+			rv = xr_usb_serial_set_reg(xr_usb_serial,reg, val);
+		}
+		else
+		{
+			rv = xr_usb_serial_set_reg_ext(xr_usb_serial,channel,reg, val);
+			
+		}
+		if (rv < 0)
+			return -EFAULT;
+		rv = 0;
+		break;
 	case XR_USB_SERIAL_LOOPBACK:
-		     if (get_user(channel, (int __user *)arg))
-                        return -EFAULT;
-		     if (channel == -1)
-			   channel = xr_usb_serial->channel;
-			 rv = xr_usb_serial_set_loopback(xr_usb_serial,channel);
-			 if (rv < 0)
-               return -EFAULT;
-			 rv = 0;
-		     break;
+		if (get_user(channel, (int __user *)arg))
+			return -EFAULT;
+		if (channel == -1)
+			channel = xr_usb_serial->channel;
+		rv = xr_usb_serial_set_loopback(xr_usb_serial,channel);
+		if (rv < 0)
+			return -EFAULT;
+		rv = 0;
+		break;
 		
 	}
 
@@ -911,15 +912,15 @@ static void xr_usb_serial_tty_set_termios(struct tty_struct *tty,
 						struct ktermios *termios_old)
 {
 	struct xr_usb_serial *xr_usb_serial = tty->driver_data;
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 7, 0)	
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 7, 0)
 	struct ktermios *termios = tty->termios;
 #else
-    struct ktermios *termios = &tty->termios;
+	struct ktermios *termios = &tty->termios;
 #endif
 	unsigned int   cflag = termios->c_cflag;
 	struct usb_cdc_line_coding newline;
 	int newctrl = xr_usb_serial->ctrlout;
-    xr_usb_serial_disable(xr_usb_serial);
+	xr_usb_serial_disable(xr_usb_serial);
 	newline.dwDTERate = cpu_to_le32(tty_get_baud_rate(tty));
 	newline.bCharFormat = termios->c_cflag & CSTOPB ? 1 : 0;
 	newline.bParityType = termios->c_cflag & PARENB ?
@@ -952,8 +953,8 @@ static void xr_usb_serial_tty_set_termios(struct tty_struct *tty,
 	if (newctrl != xr_usb_serial->ctrlout)
 		xr_usb_serial_set_control(xr_usb_serial, xr_usb_serial->ctrlout = newctrl);
 	
-    xr_usb_serial_set_flow_mode(xr_usb_serial,tty,cflag);/*set the serial flow mode*/
-	 	
+	xr_usb_serial_set_flow_mode(xr_usb_serial,tty,cflag);/*set the serial flow mode*/
+	
 	if (memcmp(&xr_usb_serial->line, &newline, sizeof newline))
 	{
 		memcpy(&xr_usb_serial->line, &newline, sizeof newline);
@@ -1056,7 +1057,7 @@ static int xr_usb_serial_probe(struct usb_interface *intf,
 
 	num_rx_buf = (quirks == SINGLE_RX_URB) ? 1 : XR_USB_SERIAL_NR;
 	
-    dev_dbg(&intf->dev, "USB_device_id idVendor:%04x, idProduct %04x\n",id->idVendor,id->idProduct);
+	dev_dbg(&intf->dev, "USB_device_id idVendor:%04x, idProduct %04x\n",id->idVendor,id->idProduct);
 	
 	/* handle quirks deadly to normal probing*/
 	if (quirks == NO_UNION_NORMAL) {
@@ -1368,10 +1369,10 @@ made_compressed_probe:
 
 		if (usb_endpoint_xfer_int(epwrite))
 			usb_fill_int_urb(snd->urb, usb_dev,
-#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 7, 0)			
+#if LINUX_VERSION_CODE < KERNEL_VERSION(3, 7, 0)
 				usb_sndbulkpipe(usb_dev, epwrite->bEndpointAddress),
 #else
-                usb_sndintpipe(usb_dev, epwrite->bEndpointAddress),
+				usb_sndintpipe(usb_dev, epwrite->bEndpointAddress),
 #endif
 				NULL, xr_usb_serial->writesize, xr_usb_serial_write_bulk, snd, epwrite->bInterval);
 		else
@@ -1427,20 +1428,20 @@ skip_countries:
 
 	dev_info(&intf->dev, "ttyXR_USB_SERIAL%d: USB XR_USB_SERIAL device\n", minor);
 	
-    xr_usb_serial_pre_setup(xr_usb_serial);
+	xr_usb_serial_pre_setup(xr_usb_serial);
 	
 	xr_usb_serial_set_control(xr_usb_serial, xr_usb_serial->ctrlout);
 
 	xr_usb_serial->line.dwDTERate = cpu_to_le32(9600);
 	xr_usb_serial->line.bDataBits = 8;
 	xr_usb_serial_set_line(xr_usb_serial, &xr_usb_serial->line);
-    
+
 	usb_driver_claim_interface(&xr_usb_serial_driver, data_interface, xr_usb_serial);
 	usb_set_intfdata(data_interface, xr_usb_serial);
 
 	usb_get_intf(control_interface);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 7, 0)
-    tty_register_device(xr_usb_serial_tty_driver, minor, &control_interface->dev);
+	tty_register_device(xr_usb_serial_tty_driver, minor, &control_interface->dev);
 #else
 	tty_dev = tty_port_register_device(&xr_usb_serial->port, xr_usb_serial_tty_driver, minor,
 			&control_interface->dev);
@@ -1622,7 +1623,7 @@ err_out:
 static int xr_usb_serial_reset_resume(struct usb_interface *intf)
 {
 	struct xr_usb_serial *xr_usb_serial = usb_get_intfdata(intf);
-    struct tty_struct *tty;
+	struct tty_struct *tty;
 	if (test_bit(ASYNCB_INITIALIZED, &xr_usb_serial->port.flags)){
 #if LINUX_VERSION_CODE > KERNEL_VERSION(3, 9, 0)	
 	tty_port_tty_hangup(&xr_usb_serial->port, false);
@@ -1644,17 +1645,17 @@ static int xr_usb_serial_reset_resume(struct usb_interface *intf)
  */
 static const struct usb_device_id xr_usb_serial_ids[] = {
 	{ USB_DEVICE(0x04e2, 0x1410)},
-    { USB_DEVICE(0x04e2, 0x1411)},
+	{ USB_DEVICE(0x04e2, 0x1411)},
 	{ USB_DEVICE(0x04e2, 0x1412)},
 	{ USB_DEVICE(0x04e2, 0x1414)},
 	{ USB_DEVICE(0x04e2, 0x1420)},
-    { USB_DEVICE(0x04e2, 0x1421)},
+	{ USB_DEVICE(0x04e2, 0x1421)},
 	{ USB_DEVICE(0x04e2, 0x1422)},
 	{ USB_DEVICE(0x04e2, 0x1424)},
 	{ USB_DEVICE(0x04e2, 0x1400)},
-    { USB_DEVICE(0x04e2, 0x1401)},
-    { USB_DEVICE(0x04e2, 0x1402)},
-    { USB_DEVICE(0x04e2, 0x1403)},
+	{ USB_DEVICE(0x04e2, 0x1401)},
+	{ USB_DEVICE(0x04e2, 0x1402)},
+	{ USB_DEVICE(0x04e2, 0x1403)},
 	{ }
 };
 

--- a/xr_usb_serial_common-1a/xr_usb_serial_common.h
+++ b/xr_usb_serial_common-1a/xr_usb_serial_common.h
@@ -26,8 +26,8 @@
  * Major and minor numbers.
  */
 
-#define XR_USB_SERIAL_TTY_MAJOR		    266
-#define XR_USB_SERIAL_TTY_MINORS		32
+#define XR_USB_SERIAL_TTY_MAJOR		266
+#define XR_USB_SERIAL_TTY_MINORS	32
 
 /*
  * Requests.
@@ -52,7 +52,7 @@
 #define XR_USB_SERIAL_CTRL_RI		0x08
 
 #define XR_USB_SERIAL_CTRL_FRAMING	0x10
-#define XR_USB_SERIAL_CTRL_PARITY		0x20
+#define XR_USB_SERIAL_CTRL_PARITY	0x20
 #define XR_USB_SERIAL_CTRL_OVERRUN	0x40
 
 /*
@@ -92,7 +92,7 @@ struct reg_addr_map {
 	unsigned int    uart_format_addr;
 	unsigned int    uart_flow_addr;
 	unsigned int    uart_loopback_addr;
-    unsigned int    uart_xon_char_addr;
+	unsigned int    uart_xon_char_addr;
 	unsigned int    uart_xoff_char_addr;
 	unsigned int    uart_gpio_mode_addr;
 	unsigned int    uart_gpio_dir_addr;
@@ -108,7 +108,7 @@ struct xr_usb_serial {
 	struct usb_device *dev;				/* the corresponding usb device */
 	struct usb_interface *control;			/* control interface */
 	struct usb_interface *data;			/* data interface */
-	struct tty_port port;			 	/* our tty port data */
+	struct tty_port port;				/* our tty port data */
 	struct urb *ctrlurb;				/* urbs */
 	u8 *ctrl_buffer;				/* buffers of urbs */
 	dma_addr_t ctrl_dma;				/* dma handles of buffers */
@@ -142,7 +142,7 @@ struct xr_usb_serial {
 	unsigned int throttled:1;			/* actually throttled */
 	unsigned int throttle_req:1;			/* throttle requested */
 	u8 bInterval;
-	struct xr_usb_serial_wb *delayed_wb;			/* write queued for a device about to be woken */
+	struct xr_usb_serial_wb *delayed_wb;		/* write queued for a device about to be woken */
 	unsigned int channel;
 	unsigned short DeviceVendor;
 	unsigned short DeviceProduct;
@@ -160,27 +160,23 @@ struct xr_usb_serial {
 #define IGNORE_DEVICE			32
 
 
-#define UART_ENABLE_TX                     1
-#define UART_ENABLE_RX                     2
+#define UART_ENABLE_TX                      1
+#define UART_ENABLE_RX                      2
 
-#define UART_GPIO_CLR_DTR                0x8
-#define UART_GPIO_SET_DTR                0x8
-#define UART_GPIO_CLR_RTS                0x20         
+#define UART_GPIO_CLR_DTR                0x08
+#define UART_GPIO_SET_DTR                0x08
+#define UART_GPIO_CLR_RTS                0x20
 #define UART_GPIO_SET_RTS                0x20
 
-#define LOOPBACK_ENABLE_TX_RX             1
-#define LOOPBACK_ENABLE_RTS_CTS           2
-#define LOOPBACK_ENABLE_DTR_DSR           4
+#define LOOPBACK_ENABLE_TX_RX               1
+#define LOOPBACK_ENABLE_RTS_CTS             2
+#define LOOPBACK_ENABLE_DTR_DSR             4
 
-#define UART_FLOW_MODE_NONE              0x0
-#define UART_FLOW_MODE_HW                0x1
-#define UART_FLOW_MODE_SW                0x2
+#define UART_FLOW_MODE_NONE               0x0
+#define UART_FLOW_MODE_HW                 0x1
+#define UART_FLOW_MODE_SW                 0x2
 
-#define UART_GPIO_MODE_SEL_GPIO          0x0
-#define UART_GPIO_MODE_SEL_RTS_CTS       0x1
+#define UART_GPIO_MODE_SEL_GPIO           0x0
+#define UART_GPIO_MODE_SEL_RTS_CTS        0x1
 
-#define XR2280x_FUNC_MGR_OFFSET           0x40
-
-
-
-
+#define XR2280x_FUNC_MGR_OFFSET          0x40

--- a/xr_usb_serial_common-1a/xr_usb_serial_hal.c
+++ b/xr_usb_serial_common-1a/xr_usb_serial_hal.c
@@ -34,7 +34,7 @@ int xr_usb_serial_set_reg(struct xr_usb_serial *xr_usb_serial,int regnum, int va
 	dev_dbg(&xr_usb_serial->control->dev, "%s Channel:%d 0x%02x = 0x%02x\n", __func__,channel,regnum, value);
 	if((xr_usb_serial->DeviceProduct&0xfff0) == 0x1400)
 	{
-	    int XR2280xaddr = XR2280x_FUNC_MGR_OFFSET + regnum; 
+		int XR2280xaddr = XR2280x_FUNC_MGR_OFFSET + regnum; 
 		result = usb_control_msg(xr_usb_serial->dev,                     /* usb device */
 	                             usb_sndctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
 	                             XR_SET_MAP_XR2280X,                      /* request */
@@ -44,7 +44,6 @@ int xr_usb_serial_set_reg(struct xr_usb_serial *xr_usb_serial,int regnum, int va
 	                             NULL,                            /* data */
 	                             0,                               /* size */
 	                             5000);                           /* timeout */
-
 	}
 	else if((xr_usb_serial->DeviceProduct == 0x1410) ||
 		    (xr_usb_serial->DeviceProduct == 0x1412) ||
@@ -53,19 +52,19 @@ int xr_usb_serial_set_reg(struct xr_usb_serial *xr_usb_serial,int regnum, int va
 
 		if(xr_usb_serial->channel)
 			channel = xr_usb_serial->channel - 1;
- 		result = usb_control_msg(xr_usb_serial->dev,					  /* usb device */
-										usb_sndctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
-										XR_SET_MAP_XR21V141X, 					 /* request */
-										USB_DIR_OUT | USB_TYPE_VENDOR,	 /* request_type */
-										value,							 /* request value */
-										regnum | (channel << 8),			 /* index */
-										NULL,							 /* data */
-										0,								 /* size */
-										5000);							 /* timeout */
+		result = usb_control_msg(xr_usb_serial->dev,             /* usb device */
+                                 usb_sndctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
+                                 XR_SET_MAP_XR21V141X,                   /* request */
+                                 USB_DIR_OUT | USB_TYPE_VENDOR,          /* request_type */
+                                 value,                                  /* request value */
+                                 regnum | (channel << 8),                /* index */
+                                 NULL,                                   /* data */
+                                 0,                                      /* size */
+                                 5000);                                  /* timeout */
 	}
 	else if(xr_usb_serial->DeviceProduct == 0x1411)
 	{
-	    result = usb_control_msg(xr_usb_serial->dev,                     /* usb device */
+		result = usb_control_msg(xr_usb_serial->dev,             /* usb device */
                                  usb_sndctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
                                  XR_SET_MAP_XR21B1411,                   /* request */
                                  USB_DIR_OUT | USB_TYPE_VENDOR ,        /* request_type */
@@ -78,11 +77,9 @@ int xr_usb_serial_set_reg(struct xr_usb_serial *xr_usb_serial,int regnum, int va
 	else if((xr_usb_serial->DeviceProduct == 0x1420)||
 		   (xr_usb_serial->DeviceProduct == 0x1422)||
 		   (xr_usb_serial->DeviceProduct == 0x1424))
-		
 	{
-	   
 		channel = (xr_usb_serial->channel - 4)*2;
-        result = usb_control_msg(xr_usb_serial->dev,                     /* usb device */
+		result = usb_control_msg(xr_usb_serial->dev,             /* usb device */
                                  usb_sndctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
                                  XR_SET_MAP_XR21B142X,                   /* request */
                                  USB_DIR_OUT | USB_TYPE_VENDOR | 1,   /* request_type */
@@ -98,9 +95,8 @@ int xr_usb_serial_set_reg(struct xr_usb_serial *xr_usb_serial,int regnum, int va
 	}
 	if(result < 0)
 		dev_dbg(&xr_usb_serial->control->dev, "%s Error:%d\n", __func__,result);
-    return result;
+	return result;
 	
-       
 }
 int xr_usb_serial_set_reg_ext(struct xr_usb_serial *xr_usb_serial,int channel,int regnum, int value)
 {
@@ -110,33 +106,33 @@ int xr_usb_serial_set_reg_ext(struct xr_usb_serial *xr_usb_serial,int channel,in
 	if((xr_usb_serial->DeviceProduct&0xfff0) == 0x1400)
 	{
 		result = usb_control_msg(xr_usb_serial->dev,                     /* usb device */
-	                             usb_sndctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
-	                             XR_SET_MAP_XR2280X,                      /* request */
-	                             USB_DIR_OUT | USB_TYPE_VENDOR,   /* request_type */
-	                             value,                           /* request value */
-	                             XR2280xaddr,           /* index */
-	                             NULL,                            /* data */
-	                             0,                               /* size */
-	                             5000);                           /* timeout */
+                                     usb_sndctrlpipe(xr_usb_serial->dev, 0),     /* endpoint pipe */
+                                     XR_SET_MAP_XR2280X,                 /* request */
+                                     USB_DIR_OUT | USB_TYPE_VENDOR,      /* request_type */
+                                     value,                              /* request value */
+                                     XR2280xaddr,                        /* index */
+                                     NULL,                               /* data */
+                                     0,                                  /* size */
+                                     5000);                              /* timeout */
 
 	}
 	else if((xr_usb_serial->DeviceProduct == 0x1410) ||
 		    (xr_usb_serial->DeviceProduct == 0x1412) ||
 		    (xr_usb_serial->DeviceProduct == 0x1414))
 	{
-       	result = usb_control_msg(xr_usb_serial->dev,					  /* usb device */
-										usb_sndctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
-										XR_SET_MAP_XR21V141X, 					 /* request */
-										USB_DIR_OUT | USB_TYPE_VENDOR,	 /* request_type */
-										value,							 /* request value */
-										regnum | (channel << 8),			 /* index */
-										NULL,							 /* data */
-										0,								 /* size */
-										5000);							 /* timeout */
+		result = usb_control_msg(xr_usb_serial->dev,             /* usb device */
+                                 usb_sndctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
+                                 XR_SET_MAP_XR21V141X, 	                 /* request */
+                                 USB_DIR_OUT | USB_TYPE_VENDOR,          /* request_type */
+                                 value,                                  /* request value */
+                                 regnum | (channel << 8),                /* index */
+                                 NULL,                                   /* data */
+                                 0,                                      /* size */
+                                 5000);                                  /* timeout */
 	}
 	else if(xr_usb_serial->DeviceProduct == 0x1411)
 	{
-	    result = usb_control_msg(xr_usb_serial->dev,                     /* usb device */
+		result = usb_control_msg(xr_usb_serial->dev,             /* usb device */
                                  usb_sndctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
                                  XR_SET_MAP_XR21B1411,                   /* request */
                                  USB_DIR_OUT | USB_TYPE_VENDOR ,        /* request_type */
@@ -148,9 +144,9 @@ int xr_usb_serial_set_reg_ext(struct xr_usb_serial *xr_usb_serial,int channel,in
 	}
 	else if((xr_usb_serial->DeviceProduct == 0x1420)||
 		    (xr_usb_serial->DeviceProduct == 0x1422)||
-		     (xr_usb_serial->DeviceProduct == 0x1424))
+		    (xr_usb_serial->DeviceProduct == 0x1424))
 	{
-	    result = usb_control_msg(xr_usb_serial->dev,                     /* usb device */
+		result = usb_control_msg(xr_usb_serial->dev,             /* usb device */
                                  usb_sndctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
                                  XR_SET_MAP_XR21B142X,                   /* request */
                                  USB_DIR_OUT | USB_TYPE_VENDOR | 1,   /* request_type */
@@ -162,13 +158,12 @@ int xr_usb_serial_set_reg_ext(struct xr_usb_serial *xr_usb_serial,int channel,in
 	}
 	else
 	{
-	    result = -1;
+		result = -1;
 	}
 	if(result < 0)
 		dev_dbg(&xr_usb_serial->control->dev, "%s Error:%d\n", __func__,result);
-    return result;
+	return result;
 	
-       
 }
 
 int xr_usb_serial_get_reg(struct xr_usb_serial *xr_usb_serial,int regnum, short *value)
@@ -179,7 +174,7 @@ int xr_usb_serial_get_reg(struct xr_usb_serial *xr_usb_serial,int regnum, short 
 	if((xr_usb_serial->DeviceProduct&0xfff0) == 0x1400)
 	{
 		int XR2280xaddr = XR2280x_FUNC_MGR_OFFSET + regnum; 
-    	result = usb_control_msg(xr_usb_serial->dev,                     /* usb device */
+		result = usb_control_msg(xr_usb_serial->dev,             /* usb device */
                                  usb_rcvctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
                                  XR_GET_MAP_XR2280X,                     /* request */
                                  USB_DIR_IN | USB_TYPE_VENDOR ,    /* request_type */
@@ -188,17 +183,14 @@ int xr_usb_serial_get_reg(struct xr_usb_serial *xr_usb_serial,int regnum, short 
                                  value,                           /* data */
                                  2,                               /* size */
                                  5000);                           /* timeout */
-		
-				
-		
 	}
 	else if((xr_usb_serial->DeviceProduct == 0x1410) ||
 		    (xr_usb_serial->DeviceProduct == 0x1412) ||
 		    (xr_usb_serial->DeviceProduct == 0x1414))
 	{
-	   if(xr_usb_serial->channel)
-	   channel = xr_usb_serial->channel -1;
-       result = usb_control_msg(xr_usb_serial->dev,                     /* usb device */
+		if(xr_usb_serial->channel)
+			channel = xr_usb_serial->channel -1;
+		result = usb_control_msg(xr_usb_serial->dev,             /* usb device */
                                  usb_rcvctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
                                  XR_GET_MAP_XR21V141X,                     /* request */
                                  USB_DIR_IN | USB_TYPE_VENDOR,    /* request_type */
@@ -210,7 +202,7 @@ int xr_usb_serial_get_reg(struct xr_usb_serial *xr_usb_serial,int regnum, short 
 	}
 	else if(xr_usb_serial->DeviceProduct == 0x1411) 
 	{
-	     result = usb_control_msg(xr_usb_serial->dev,                     /* usb device */
+		result = usb_control_msg(xr_usb_serial->dev,             /* usb device */
                                  usb_rcvctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
                                  XR_GET_MAP_XR21B1411,                     /* request */
                                  USB_DIR_IN | USB_TYPE_VENDOR,    /* request_type */
@@ -223,10 +215,9 @@ int xr_usb_serial_get_reg(struct xr_usb_serial *xr_usb_serial,int regnum, short 
 	else if((xr_usb_serial->DeviceProduct == 0x1420)||
 		    (xr_usb_serial->DeviceProduct == 0x1422)||
 		    (xr_usb_serial->DeviceProduct == 0x1424))
-		   
 	{
-	  channel = (xr_usb_serial->channel -4)*2;
-      result = usb_control_msg(xr_usb_serial->dev,                     /* usb device */
+		channel = (xr_usb_serial->channel -4)*2;
+		result = usb_control_msg(xr_usb_serial->dev,             /* usb device */
                                  usb_rcvctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
                                  XR_GET_MAP_XR21B142X,                     /* request */
                                  USB_DIR_IN | USB_TYPE_VENDOR | 1,    /* request_type */
@@ -238,13 +229,13 @@ int xr_usb_serial_get_reg(struct xr_usb_serial *xr_usb_serial,int regnum, short 
 	}
 	else
 	{
-	    result = -1;
+		result = -1;
 	}
 	
 	if(result < 0)
 		dev_dbg(&xr_usb_serial->control->dev, "%s channel:%d Reg 0x%x Error:%d\n", __func__,channel,regnum,result);
 	else
-	    dev_dbg(&xr_usb_serial->control->dev, "%s channel:%d 0x%x = 0x%04x\n", __func__,channel,regnum, *value);
+		dev_dbg(&xr_usb_serial->control->dev, "%s channel:%d 0x%x = 0x%04x\n", __func__,channel,regnum, *value);
 	
 	return result;
 
@@ -257,8 +248,7 @@ int xr_usb_serial_get_reg_ext(struct xr_usb_serial *xr_usb_serial,int channel,in
 	int XR2280xaddr = XR2280x_FUNC_MGR_OFFSET + regnum; 
 	if((xr_usb_serial->DeviceProduct&0xfff0) == 0x1400)
 	{
-		
-    	result = usb_control_msg(xr_usb_serial->dev,                     /* usb device */
+		result = usb_control_msg(xr_usb_serial->dev,             /* usb device */
                                  usb_rcvctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
                                  XR_GET_MAP_XR2280X,                     /* request */
                                  USB_DIR_IN | USB_TYPE_VENDOR ,    /* request_type */
@@ -267,16 +257,13 @@ int xr_usb_serial_get_reg_ext(struct xr_usb_serial *xr_usb_serial,int channel,in
                                  value,                           /* data */
                                  2,                               /* size */
                                  5000);                           /* timeout */
-		
-				
-		
 	}
 	else if((xr_usb_serial->DeviceProduct == 0x1410) ||
 		    (xr_usb_serial->DeviceProduct == 0x1412) ||
 		    (xr_usb_serial->DeviceProduct == 0x1414))
 	{
-	   unsigned char reg_value = 0;
-	   result = usb_control_msg(xr_usb_serial->dev,                     /* usb device */
+		unsigned char reg_value = 0;
+		result = usb_control_msg(xr_usb_serial->dev,             /* usb device */
                                  usb_rcvctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
                                  XR_GET_MAP_XR21V141X,                     /* request */
                                  USB_DIR_IN | USB_TYPE_VENDOR,    /* request_type */
@@ -285,12 +272,12 @@ int xr_usb_serial_get_reg_ext(struct xr_usb_serial *xr_usb_serial,int channel,in
                                  &reg_value,                           /* data */
                                  1,                               /* size */
                                  5000);                           /* timeout */
-	   dev_dbg(&xr_usb_serial->control->dev, "xr_usb_serial_get_reg_ext reg:%x\n",reg_value);
-	   *value = reg_value; 
+		dev_dbg(&xr_usb_serial->control->dev, "xr_usb_serial_get_reg_ext reg:%x\n",reg_value);
+		*value = reg_value; 
 	}
 	else if(xr_usb_serial->DeviceProduct == 0x1411) 
 	{
-	     result = usb_control_msg(xr_usb_serial->dev,                     /* usb device */
+		result = usb_control_msg(xr_usb_serial->dev,             /* usb device */
                                  usb_rcvctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
                                  XR_GET_MAP_XR21B1411,                     /* request */
                                  USB_DIR_IN | USB_TYPE_VENDOR ,       /* request_type */
@@ -304,7 +291,7 @@ int xr_usb_serial_get_reg_ext(struct xr_usb_serial *xr_usb_serial,int channel,in
 		    (xr_usb_serial->DeviceProduct == 0x1422)||
 		    (xr_usb_serial->DeviceProduct == 0x1424))
 	{
-	   result = usb_control_msg(xr_usb_serial->dev,                     /* usb device */
+		result = usb_control_msg(xr_usb_serial->dev,             /* usb device */
                                  usb_rcvctrlpipe(xr_usb_serial->dev, 0), /* endpoint pipe */
                                  XR_GET_MAP_XR21B142X,                     /* request */
                                  USB_DIR_IN | USB_TYPE_VENDOR | 1,    /* request_type */
@@ -316,13 +303,13 @@ int xr_usb_serial_get_reg_ext(struct xr_usb_serial *xr_usb_serial,int channel,in
 	}
 	else
 	{
-	    result = -1;
+		result = -1;
 	}
 	
 	if(result < 0)
 		dev_dbg(&xr_usb_serial->control->dev, "%s Error:%d\n", __func__,result);
 	else
-	    dev_dbg(&xr_usb_serial->control->dev, "%s channel:%d 0x%x = 0x%04x\n", __func__,channel,regnum, *value);
+		dev_dbg(&xr_usb_serial->control->dev, "%s channel:%d 0x%x = 0x%04x\n", __func__,channel,regnum, *value);
 	
 	return result;
 
@@ -401,77 +388,77 @@ static int xr21v141x_set_baud_rate(struct xr_usb_serial *xr_usb_serial, unsigned
  */
 int xr_usb_serial_set_control(struct xr_usb_serial *xr_usb_serial, unsigned int control)
 {
-    int ret = 0;
-    
+	int ret = 0;
+	
 	if((xr_usb_serial->DeviceProduct == 0x1410) ||
 		   (xr_usb_serial->DeviceProduct == 0x1412) || 
 		   (xr_usb_serial->DeviceProduct == 0x1414)) 
 	{
 		if (control & XR_USB_SERIAL_CTRL_DTR) 
-		   xr_usb_serial_set_reg(xr_usb_serial,xr_usb_serial->reg_map.uart_gpio_clr_addr, 0x08);
+			xr_usb_serial_set_reg(xr_usb_serial,xr_usb_serial->reg_map.uart_gpio_clr_addr, 0x08);
 		else
-		   xr_usb_serial_set_reg(xr_usb_serial,xr_usb_serial->reg_map.uart_gpio_set_addr, 0x08);
+			xr_usb_serial_set_reg(xr_usb_serial,xr_usb_serial->reg_map.uart_gpio_set_addr, 0x08);
 
 		if (control & XR_USB_SERIAL_CTRL_RTS) 
-		   xr_usb_serial_set_reg(xr_usb_serial,xr_usb_serial->reg_map.uart_gpio_clr_addr, 0x20);
+			xr_usb_serial_set_reg(xr_usb_serial,xr_usb_serial->reg_map.uart_gpio_clr_addr, 0x20);
 		else
-		   xr_usb_serial_set_reg(xr_usb_serial,xr_usb_serial->reg_map.uart_gpio_set_addr, 0x20);
+			xr_usb_serial_set_reg(xr_usb_serial,xr_usb_serial->reg_map.uart_gpio_set_addr, 0x20);
 	}
 	else 
 	{
-	   ret = xr_usb_serial_ctrl_msg(xr_usb_serial, USB_CDC_REQ_SET_CONTROL_LINE_STATE, control, NULL, 0);
+		ret = xr_usb_serial_ctrl_msg(xr_usb_serial, USB_CDC_REQ_SET_CONTROL_LINE_STATE, control, NULL, 0);
 	}
 	
 	return ret;
 }
 
 int xr_usb_serial_set_line(struct xr_usb_serial *xr_usb_serial, struct usb_cdc_line_coding* line)
- {
-	 int ret = 0;
-	 unsigned int format_size;
-	 unsigned int format_parity;
-	 unsigned int format_stop;
-	 if((xr_usb_serial->DeviceProduct == 0x1410) ||
+{
+	int ret = 0;
+	unsigned int format_size;
+	unsigned int format_parity;
+	unsigned int format_stop;
+	if((xr_usb_serial->DeviceProduct == 0x1410) ||
 		(xr_usb_serial->DeviceProduct == 0x1412) || 
 		(xr_usb_serial->DeviceProduct == 0x1414)) 
-	 {
+	{
 		xr21v141x_set_baud_rate(xr_usb_serial,line->dwDTERate);
 		format_size = line->bDataBits;
 		format_parity = line->bParityType;
 		format_stop = line->bCharFormat;
 		xr_usb_serial_set_reg(xr_usb_serial,
-			                  xr_usb_serial->reg_map.uart_format_addr,
-			                  (format_size << 0) | (format_parity << 4) | (format_stop << 7) );
+			   xr_usb_serial->reg_map.uart_format_addr,
+			   (format_size << 0) | (format_parity << 4) | (format_stop << 7) );
 		
-	 }
-	 else 
-	 {
-	   ret = xr_usb_serial_ctrl_msg(xr_usb_serial, USB_CDC_REQ_SET_LINE_CODING, 0, line, sizeof *(line));
-	 }
-	 return ret;
- }
- int xr_usb_serial_set_flow_mode(struct xr_usb_serial *xr_usb_serial, 
- 	                                     struct tty_struct *tty, unsigned int cflag)
- {
+	}
+	else 
+	{
+		ret = xr_usb_serial_ctrl_msg(xr_usb_serial, USB_CDC_REQ_SET_LINE_CODING, 0, line, sizeof *(line));
+	}
+	return ret;
+}
+int xr_usb_serial_set_flow_mode(struct xr_usb_serial *xr_usb_serial, 
+	                                     struct tty_struct *tty, unsigned int cflag)
+{
 	unsigned int flow;
 	unsigned int gpio_mode;
 	
 	if (cflag & CRTSCTS)
 	{
-	    dev_dbg(&xr_usb_serial->control->dev, "xr_usb_serial_set_flow_mode:hardware\n");
-	    flow      = UART_FLOW_MODE_HW;
-	    gpio_mode = UART_GPIO_MODE_SEL_RTS_CTS;
+		dev_dbg(&xr_usb_serial->control->dev, "xr_usb_serial_set_flow_mode:hardware\n");
+		flow      = UART_FLOW_MODE_HW;
+		gpio_mode = UART_GPIO_MODE_SEL_RTS_CTS;
 	} 
 	else if (I_IXOFF(tty) || I_IXON(tty))
 	{
-	    unsigned char   start_char = START_CHAR(tty);
-	    unsigned char   stop_char  = STOP_CHAR(tty);
-        dev_dbg(&xr_usb_serial->control->dev, "xr_usb_serial_set_flow_mode:software\n");
-	    flow      = UART_FLOW_MODE_SW;
-	    gpio_mode = UART_GPIO_MODE_SEL_GPIO;
+		unsigned char   start_char = START_CHAR(tty);
+		unsigned char   stop_char  = STOP_CHAR(tty);
+		dev_dbg(&xr_usb_serial->control->dev, "xr_usb_serial_set_flow_mode:software\n");
+		flow      = UART_FLOW_MODE_SW;
+		gpio_mode = UART_GPIO_MODE_SEL_GPIO;
 
-	    xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_xon_char_addr, start_char);
-	    xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_xoff_char_addr, stop_char);
+		xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_xon_char_addr, start_char);
+		xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_xoff_char_addr, stop_char);
 	}
 	else
 	{
@@ -479,11 +466,11 @@ int xr_usb_serial_set_line(struct xr_usb_serial *xr_usb_serial, struct usb_cdc_l
 	    flow      = UART_FLOW_MODE_NONE;
 	    gpio_mode = UART_GPIO_MODE_SEL_GPIO;
 	}
-    xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_flow_addr, flow);
-    gpio_mode = 0x0b; // FIXME hardcoded to RS-485
-    xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_gpio_mode_addr, gpio_mode);
+	xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_flow_addr, flow);
+	gpio_mode = 0x0b; // FIXME hardcoded to RS-485
+	xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_gpio_mode_addr, gpio_mode);
 	return 0;
-	 
+	
 
  }
  
@@ -494,14 +481,14 @@ int xr_usb_serial_send_break(struct xr_usb_serial *xr_usb_serial, int state)
 	   (xr_usb_serial->DeviceProduct == 0x1412)||
 	   (xr_usb_serial->DeviceProduct == 0x1414))
 	{
-	  if(state)
-	     ret = xr_usb_serial_set_reg(xr_usb_serial,xr_usb_serial->reg_map.tx_break_addr,0xffff);
-	  else
-	  	 ret = xr_usb_serial_set_reg(xr_usb_serial,xr_usb_serial->reg_map.tx_break_addr,0);
+		if(state)
+			ret = xr_usb_serial_set_reg(xr_usb_serial,xr_usb_serial->reg_map.tx_break_addr,0xffff);
+		else
+			ret = xr_usb_serial_set_reg(xr_usb_serial,xr_usb_serial->reg_map.tx_break_addr,0);
 	}
 	else 
 	{
-	  ret = xr_usb_serial_ctrl_msg(xr_usb_serial, USB_CDC_REQ_SEND_BREAK, state, NULL, 0);
+		ret = xr_usb_serial_ctrl_msg(xr_usb_serial, USB_CDC_REQ_SEND_BREAK, state, NULL, 0);
 	}
 	return ret;
 }
@@ -525,7 +512,7 @@ int xr_usb_serial_enable(struct xr_usb_serial *xr_usb_serial)
 	}
 	else 
 	{
-	  ret = xr_usb_serial_set_reg(xr_usb_serial,xr_usb_serial->reg_map.uart_enable_addr,UART_ENABLE_TX | UART_ENABLE_RX);
+		ret = xr_usb_serial_set_reg(xr_usb_serial,xr_usb_serial->reg_map.uart_enable_addr,UART_ENABLE_TX | UART_ENABLE_RX);
 	}
 	
 	return ret;
@@ -539,7 +526,7 @@ int xr_usb_serial_disable(struct xr_usb_serial *xr_usb_serial)
 	   (xr_usb_serial->DeviceProduct == 0x1412)||
 	   (xr_usb_serial->DeviceProduct == 0x1414))
 	{
-	  ret = xr_usb_serial_set_reg_ext(xr_usb_serial,URM_REG_BLOCK,URM_ENABLE_BASE + channel,URM_ENABLE_0_TX);
+		ret = xr_usb_serial_set_reg_ext(xr_usb_serial,URM_REG_BLOCK,URM_ENABLE_BASE + channel,URM_ENABLE_0_TX);
 	}
 		
 	return ret;
@@ -558,45 +545,45 @@ int xr_usb_serial_set_loopback(struct xr_usb_serial *xr_usb_serial, int channel)
 static int xr_usb_serial_tiocmget(struct xr_usb_serial *xr_usb_serial)
 
 {
-        short data;
-		int result;
-		result = xr_usb_serial_get_reg(xr_usb_serial,xr_usb_serial->reg_map.uart_gpio_status_addr, &data);
-		dev_dbg(&xr_usb_serial->control->dev, "xr_usb_serial_tiocmget uart_gpio_status_addr:0x%04x\n",data);
-		if (result)
-			return ((data & 0x8) ? 0: TIOCM_DTR) | ((data & 0x20) ? 0:TIOCM_RTS ) | ((data & 0x4) ? 0:TIOCM_DSR) | ((data & 0x1) ? 0 : TIOCM_RI) | ((data & 0x2) ? 0:TIOCM_CD) | ((data & 0x10) ? 0 : TIOCM_CTS); 
-		else
-			return -EFAULT;
+	short data;
+	int result;
+	result = xr_usb_serial_get_reg(xr_usb_serial,xr_usb_serial->reg_map.uart_gpio_status_addr, &data);
+	dev_dbg(&xr_usb_serial->control->dev, "xr_usb_serial_tiocmget uart_gpio_status_addr:0x%04x\n",data);
+	if (result)
+		return ((data & 0x8) ? 0: TIOCM_DTR) | ((data & 0x20) ? 0:TIOCM_RTS ) | ((data & 0x4) ? 0:TIOCM_DSR) | ((data & 0x1) ? 0 : TIOCM_RI) | ((data & 0x2) ? 0:TIOCM_CD) | ((data & 0x10) ? 0 : TIOCM_CTS); 
+	else
+		return -EFAULT;
 }
 static int xr_usb_serial_tiocmset(struct xr_usb_serial *xr_usb_serial,
 
                             unsigned int set, unsigned int clear)
 
 {
-        unsigned int newctrl = 0;
-        newctrl = xr_usb_serial->ctrlout; 
+	unsigned int newctrl = 0;
+	newctrl = xr_usb_serial->ctrlout; 
 		
-        set = (set & TIOCM_DTR ? XR_USB_SERIAL_CTRL_DTR : 0) | (set & TIOCM_RTS ? XR_USB_SERIAL_CTRL_RTS : 0);
+	set = (set & TIOCM_DTR ? XR_USB_SERIAL_CTRL_DTR : 0) | (set & TIOCM_RTS ? XR_USB_SERIAL_CTRL_RTS : 0);
 		
-        clear = (clear & TIOCM_DTR ? XR_USB_SERIAL_CTRL_DTR : 0) | (clear & TIOCM_RTS ? XR_USB_SERIAL_CTRL_RTS : 0);
-       
-	    newctrl = (newctrl & ~clear) | set;
+	clear = (clear & TIOCM_DTR ? XR_USB_SERIAL_CTRL_DTR : 0) | (clear & TIOCM_RTS ? XR_USB_SERIAL_CTRL_RTS : 0);
 		
-		if (xr_usb_serial->ctrlout == newctrl)
-                return 0;
+	newctrl = (newctrl & ~clear) | set;
 		
-		xr_usb_serial->ctrlout = newctrl;
+	if (xr_usb_serial->ctrlout == newctrl)
+		return 0;
 		
-		if (newctrl & XR_USB_SERIAL_CTRL_DTR) 
-			xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_gpio_clr_addr, 0x08);
-		else
-			xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_gpio_set_addr, 0x08);
+	xr_usb_serial->ctrlout = newctrl;
+		
+	if (newctrl & XR_USB_SERIAL_CTRL_DTR) 
+		xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_gpio_clr_addr, 0x08);
+	else
+		xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_gpio_set_addr, 0x08);
 
-		if (newctrl & XR_USB_SERIAL_CTRL_RTS) 
-			xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_gpio_clr_addr, 0x20);
-		else
-			xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_gpio_set_addr, 0x20);
+	if (newctrl & XR_USB_SERIAL_CTRL_RTS) 
+		xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_gpio_clr_addr, 0x20);
+	else
+		xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_gpio_set_addr, 0x20);
 
-        return 0;
+	return 0;
 }
 
 
@@ -665,7 +652,7 @@ static void init_xr21b142x_reg_map(void)
 	xr21b142x_reg_map.uart_gpio_set_addr = 0x0e;
 	xr21b142x_reg_map.uart_gpio_clr_addr = 0x0f;
 	xr21b142x_reg_map.uart_gpio_status_addr = 0x10;
-    xr21b140x_reg_map.tx_break_addr = 0x0a;
+	xr21b140x_reg_map.tx_break_addr = 0x0a;
 	xr21b140x_reg_map.uart_custom_driver = 0x60;
 	xr21b140x_reg_map.uart_low_latency = 0x46;
 }
@@ -708,11 +695,9 @@ int xr_usb_serial_pre_setup(struct xr_usb_serial *xr_usb_serial)
 
 	xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_gpio_mode_addr, 0);  
 	xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_gpio_dir_addr, 0x28);  
-    xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_gpio_set_addr, UART_GPIO_SET_DTR | UART_GPIO_SET_RTS); 
+	xr_usb_serial_set_reg(xr_usb_serial, xr_usb_serial->reg_map.uart_gpio_set_addr, UART_GPIO_SET_DTR | UART_GPIO_SET_RTS); 
 	
-    return ret;
+	return ret;
    
 }
-
-	
-
+

--- a/xr_usb_serial_common-1a/xr_usb_serial_ioctl.h
+++ b/xr_usb_serial_common-1a/xr_usb_serial_ioctl.h
@@ -16,7 +16,7 @@
 
 #include <linux/ioctl.h>
 
-#define XR_USB_SERIAL_IOC_MAGIC       	'v'
+#define XR_USB_SERIAL_IOC_MAGIC         'v'
 
 #define XR_USB_SERIAL_GET_REG           	_IOWR(XR_USB_SERIAL_IOC_MAGIC, 1, int)
 #define XR_USB_SERIAL_SET_REG           	_IOWR(XR_USB_SERIAL_IOC_MAGIC, 2, int)
@@ -25,7 +25,7 @@
 #define XR_USB_SERIAL_TEST_MODE         	_IO(XR_USB_SERIAL_IOC_MAGIC, 5)
 #define XR_USB_SERIAL_LOOPBACK          	_IO(XR_USB_SERIAL_IOC_MAGIC, 6)
 
-#define VZ_ADDRESS_UNICAST_S        	0
-#define VZ_ADDRESS_BROADCAST_S      	8
+#define VZ_ADDRESS_UNICAST_S            0
+#define VZ_ADDRESS_BROADCAST_S          8
 #define VZ_ADDRESS_MATCH(U, B)          (0x8000000 | ((B) << VZ_ADDRESS_BROADCAST_S) | ((U) << VZ_ADDRESS_UNICAST_S))
-#define VZ_ADDRESS_MATCH_DISABLE    	0
+#define VZ_ADDRESS_MATCH_DISABLE        0


### PR DESCRIPTION
building for OpenWrt gave some compiler warnings

~~~
xr_usb_serial_common.c:878:17: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
                 if (get_user(val, (int __user *)(arg + 2 * sizeof(int))))
                 ^~
xr_usb_serial_common.c:881:4: note: ...this statement, but the latter is misleadingly indented as if it were guarded by the 'if'
    if (channel == -1)
    ^~
~~~

Unified usage of tabs and spaces, which should make the compiler happy

