### PR TITLE
Fix kernel drivers for linux 5.13 and above

### DIFF
--- a/linux_usb_serial/xr_serial.c
+++ b/linux_usb_serial/xr_serial.c
@@ -1059,7 +1059,9 @@ static void xr_port_remove(struct usb_serial_port *port)
 	struct xr_data *data = usb_get_serial_port_data(port);
 
 	kfree(data);
+#if LINUX_VERSION_CODE < KERNEL_VERSION(5,13,0)
 	return 0;
+#endif
 }
 
 #define XR_DEVICE(vid, pid, type)					\

--- a/xr_usb_serial_common-1a/xr_usb_serial_common.c
+++ b/xr_usb_serial_common-1a/xr_usb_serial_common.c
@@ -1737,14 +1737,22 @@ static int __init xr_usb_serial_init(void)
 
 	retval = tty_register_driver(xr_usb_serial_tty_driver);
 	if (retval) {
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
+		tty_driver_kref_put(xr_usb_serial_tty_driver);
+#else
 		put_tty_driver(xr_usb_serial_tty_driver);
+#endif
 		return retval;
 	}
 
 	retval = usb_register(&xr_usb_serial_driver);
 	if (retval) {
 		tty_unregister_driver(xr_usb_serial_tty_driver);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
+		tty_driver_kref_put(xr_usb_serial_tty_driver);
+#else
 		put_tty_driver(xr_usb_serial_tty_driver);
+#endif
 		return retval;
 	}
 
@@ -1757,7 +1765,12 @@ static void __exit xr_usb_serial_exit(void)
 {
 	usb_deregister(&xr_usb_serial_driver);
 	tty_unregister_driver(xr_usb_serial_tty_driver);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
+	tty_driver_kref_put(xr_usb_serial_tty_driver);
+#else
 	put_tty_driver(xr_usb_serial_tty_driver);
+#endif
+
 }
 
 module_init(xr_usb_serial_init);

--- a/xr_usb_serial_common-1a/xr_usb_serial_common.c
+++ b/xr_usb_serial_common-1a/xr_usb_serial_common.c
@@ -689,7 +689,11 @@ static int xr_usb_serial_tty_write(struct tty_struct *tty,
 	return count;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+static unsigned int xr_usb_serial_tty_write_room(struct tty_struct *tty) 
+#else
 static int xr_usb_serial_tty_write_room(struct tty_struct *tty)
+#endif
 {
 	struct xr_usb_serial *xr_usb_serial = tty->driver_data;
 	/*
@@ -699,7 +703,11 @@ static int xr_usb_serial_tty_write_room(struct tty_struct *tty)
 	return xr_usb_serial_wb_is_avail(xr_usb_serial) ? xr_usb_serial->writesize : 0;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 14, 0)
+static unsigned int xr_usb_serial_tty_chars_in_buffer(struct tty_struct *tty)
+#else
 static int xr_usb_serial_tty_chars_in_buffer(struct tty_struct *tty)
+#endif
 {
 	struct xr_usb_serial *xr_usb_serial = tty->driver_data;
 	/*

--- a/xr_usb_serial_common-1a/xr_usb_serial_common.c
+++ b/xr_usb_serial_common-1a/xr_usb_serial_common.c
@@ -1714,9 +1714,15 @@ static const struct tty_operations xr_usb_serial_ops = {
 static int __init xr_usb_serial_init(void)
 {
 	int retval;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)
+	xr_usb_serial_tty_driver = tty_alloc_driver(XR_USB_SERIAL_TTY_MINORS, 0);
+	if (IS_ERR(xr_usb_serial_tty_driver))
+		return PTR_ERR(xr_usb_serial_tty_driver);
+#else
 	xr_usb_serial_tty_driver = alloc_tty_driver(XR_USB_SERIAL_TTY_MINORS);
 	if (!xr_usb_serial_tty_driver)
 		return -ENOMEM;
+#endif
 	xr_usb_serial_tty_driver->driver_name = "xr_usb_serial",
 	xr_usb_serial_tty_driver->name = "ttyXRUSB",
 	xr_usb_serial_tty_driver->major = XR_USB_SERIAL_TTY_MAJOR,


### PR DESCRIPTION
Collection of backwards-compatible fixes for kernel version 5.13 and above.

I've verified that both drivers can be compiled and loaded on kernels 5.15 (RPi kernel) and 5.17. Also read some data using the `xr_usb_serial_common` driver - works like a charm!  
Haven't had the time yet to tinker with the experimental `xr_serial`, though :)