### PR TITLE
xr_usb: kernel 6.1 compile fix

### DIFF
--- a/xr_usb_serial_common-1a/xr_usb_serial_common.c
+++ b/xr_usb_serial_common-1a/xr_usb_serial_common.c
@@ -922,8 +922,13 @@ static int xr_usb_serial_tty_ioctl(struct tty_struct *tty,
 	return rv;
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 1, 0)
+static void xr_usb_serial_tty_set_termios(struct tty_struct *tty,
+						const struct ktermios *termios_old)
+#else
 static void xr_usb_serial_tty_set_termios(struct tty_struct *tty,
 						struct ktermios *termios_old)
+#endif
 {
 	struct xr_usb_serial *xr_usb_serial = tty->driver_data;
 #if LINUX_VERSION_CODE < KERNEL_VERSION(3, 7, 0)


### PR DESCRIPTION
kernel 6.1 includes a8c11c152034 ("tty: Make ->set_termios() old ktermios const") [0]

[0]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=a8c11c1520347be74b02312d10ef686b01b525f1

Signed-off-by: John Thomson <git@johnthomson.fastmail.com.au>

---
only compile tested with openwrt toolchain: aarch64 kernel 6.1rc1 + kernel 5.10