### PR TITLE
Support Linux 6.12

### DIFF
--- a/xr_usb_serial_common-1a/xr_usb_serial_common.c
+++ b/xr_usb_serial_common-1a/xr_usb_serial_common.c
@@ -48,9 +48,13 @@
 #include <linux/usb.h>
 #include <linux/usb/cdc.h>
 #include <asm/byteorder.h>
-#include <asm/unaligned.h>
-#include <linux/list.h>
 #include "linux/version.h"
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,12,0)
+#include <linux/unaligned.h>
+#else
+#include <asm/unaligned.h>
+#endif
+#include <linux/list.h>
 
 #include "xr_usb_serial_common.h"
 #include "xr_usb_serial_ioctl.h"
@@ -643,8 +647,14 @@ static void xr_usb_serial_tty_close(struct tty_struct *tty, struct file *filp)
 	tty_port_close(&xr_usb_serial->port, tty, filp);
 }
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6,6,0)
+static ssize_t xr_usb_serial_tty_write(struct tty_struct *tty,
+					const u8 *buf,
+					size_t count)
+#else
 static int xr_usb_serial_tty_write(struct tty_struct *tty,
 					const unsigned char *buf, int count)
+#endif
 {
 	struct xr_usb_serial *xr_usb_serial = tty->driver_data;
 	int stat;


### PR DESCRIPTION
This pull request updates the `xr_usb_serial_common-1a/xr_usb_serial_common.c` driver to improve compatibility with newer Linux kernel versions. The main changes involve conditional compilation to select the correct headers and function signatures based on the kernel version.

Kernel compatibility improvements:

* Updated the inclusion of `unaligned.h` to use the correct path for Linux kernels 6.12.0 and above, switching from `<asm/unaligned.h>` to `<linux/unaligned.h>` for newer kernels. (`xr_usb_serial_common-1a/xr_usb_serial_common.c`)
* Modified the signature of the `xr_usb_serial_tty_write` function to use the new prototype (`ssize_t` return type and `const u8 *buf` parameter) for kernels 6.6.0 and above, while retaining the old signature for older kernels. (`xr_usb_serial_common-1a/xr_usb_serial_common.c`)